### PR TITLE
Removed global google provider

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,8 +1,3 @@
-provider "google" {
-  project = var.project
-  region  = var.region
-}
-
 data "google_client_config" "provider" {}
 
 data "google_container_cluster" "my_cluster" {


### PR DESCRIPTION
## What
Removed google provider

## Why
Providers are global scoped and providing it in module conflicts with calling terraform code
